### PR TITLE
query: support store config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#2008](https://github.com/thanos-io/thanos/pull/2008) Querier, Receiver, Sidecar, Store: Add gRPC [health check](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) endpoints.
 - [#2145](https://github.com/thanos-io/thanos/pull/2145) Tracing: track query sent to prometheus via remote read api.
 - [#2113](https://github.com/thanos-io/thanos/pull/2113) Bucket: Added `thanos bucket replicate`.
+- [#TODO](https://github.com/thanos-io/thanos/pull/TODO) Query: Add ability to mix Store TLS configuration with the `--store.config` amd `--store.config-file` CLI flags. See [documentation](docs/components/query.md/#configuration) for further information.
 
 ### Changed
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -226,8 +226,9 @@ func runQuery(
 	reg.MustRegister(duplicatedStores)
 
 
-	var storesConfig *store.Config
+	var storesConfig []store.Config
 	if len(storeConfigYAML) > 0 {
+		level.Info(logger).Log("msg", string(storeConfigYAML))
 		var err error
 		storesConfig, err = store.LoadConfig(storeConfigYAML)
 		if err != nil {
@@ -246,7 +247,7 @@ func runQuery(
 		if fileSDConfig != nil {
 			endpointsConfig.FileSDConfigs = []file.SDConfig{*fileSDConfig}
 		}
-		storeConfig := store.StoresConfig{
+		storeConfig := store.Config{
 			EndpointsConfig: endpointsConfig,
 		}
 		if secure {
@@ -258,9 +259,7 @@ func runQuery(
 			}
 		}
 
-		storesConfig = &store.Config{
-			Stores: []store.StoresConfig{ storeConfig },
-		}
+		storesConfig = []store.Config{ storeConfig }
 	}
 
 	// todo: sml: remove - for debugging
@@ -291,7 +290,7 @@ func runQuery(
 		)
 	)
 
-	for _, config := range storesConfig.Stores {
+	for _, config := range storesConfig {
 		var fileSD *file.Discovery
 		if config.EndpointsConfig.FileSDConfigs != nil {
 			fileSD = file.NewDiscovery(fileSDConfig, logger)

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -228,7 +228,6 @@ func runQuery(
 
 	var storesConfig []store.Config
 	if len(storeConfigYAML) > 0 {
-		level.Info(logger).Log("msg", string(storeConfigYAML))
 		var err error
 		storesConfig, err = store.LoadConfig(storeConfigYAML)
 		if err != nil {

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -291,7 +291,7 @@ func runQuery(
 
 	for _, config := range storesConfig {
 		var fileSD *file.Discovery
-		if config.EndpointsConfig.FileSDConfigs != nil {
+		if config.EndpointsConfig.FileSDConfigs != nil && len(config.EndpointsConfig.FileSDConfigs) > 0 {
 			fileSD = file.NewDiscovery(fileSDConfig, logger)
 		}
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -132,7 +132,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 
 		var fileSDConfig *file.SDConfig
 		if len(*fileSDFiles) > 0 {
-			fileSDConfig := &file.SDConfig{
+			fileSDConfig = &file.SDConfig{
 				Files:           *fileSDFiles,
 				RefreshInterval: *fileSDInterval,
 			}
@@ -253,7 +253,7 @@ func runQuery(
 			    TlsConfig: &tlsConfig,
 				EndpointsConfig: store.EndpointsConfig {
 					StaticAddresses: storeAddrs,
-					FileSDConfigs: fileSDConfig,
+					FileSDConfigs: []file.SDConfig{*fileSDConfig},
 				},
 			},
 		)

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -359,6 +359,7 @@ func runQuery(
 			}
 
 			ctxUpdate, cancelUpdate := context.WithCancel(context.Background())
+			staticAddresses := config.EndpointsConfig.StaticAddresses
 			g.Add(func() error {
 				for {
 					select {
@@ -369,7 +370,7 @@ func runQuery(
 						}
 						fileSDCache.Update(update)
 						stores.Update(ctxUpdate)
-						dnsProvider.Resolve(ctxUpdate, append(fileSDCache.Addresses(), config.EndpointsConfig.StaticAddresses...))
+						dnsProvider.Resolve(ctxUpdate, append(fileSDCache.Addresses(), staticAddresses...))
 					case <-ctxUpdate.Done():
 						return nil
 					}
@@ -382,9 +383,10 @@ func runQuery(
 		// Periodically update the addresses from static flags and file SD by resolving them using DNS SD if necessary.
 		{
 			ctx, cancel := context.WithCancel(context.Background())
+			staticAddresses := config.EndpointsConfig.StaticAddresses
 			g.Add(func() error {
 				return runutil.Repeat(dnsSDInterval, ctx.Done(), func() error {
-					dnsProvider.Resolve(ctx, append(fileSDCache.Addresses(), config.EndpointsConfig.StaticAddresses...))
+					dnsProvider.Resolve(ctx, append(fileSDCache.Addresses(), staticAddresses...))
 					return nil
 				})
 			}, func(error) {

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -6,6 +6,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/thanos-io/thanos/pkg/extflag"
+	http_util "github.com/thanos-io/thanos/pkg/http"
 	"math"
 	"net/http"
 	"path"
@@ -76,6 +78,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 	stores := cmd.Flag("store", "Addresses of statically configured store API servers (repeatable). The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect store API servers through respective DNS lookups.").
 		PlaceHolder("<store>").Strings()
 
+	storeConfig := extflag.RegisterPathOrContent(cmd, "store.config", "YAML file that contains store API servers configuration. See format details: https://thanos.io/components/query.md/#configuration. If defined, it takes precedence over the '--store' and '--store.sd-files' flags.", false)
+
 	fileSDFiles := cmd.Flag("store.sd-files", "Path to files that contain addresses of store API servers. The path can be a glob pattern (repeatable).").
 		PlaceHolder("<path>").Strings()
 
@@ -116,13 +120,23 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 			lookupStores[s] = struct{}{}
 		}
 
-		var fileSD *file.Discovery
+		storeConfigYAML, err := storeConfig.Content()
+		if err != nil {
+			return err
+		}
+		if len(*fileSDFiles) == 0 && len(*stores) == 0 && len(storeConfigYAML) == 0 {
+			return errors.New("no --store parameter was given")
+		}
+		if (len(*fileSDFiles) != 0 || len(*stores) != 0) && len(storeConfigYAML) != 0 {
+			return errors.New("--store/--store.sd-files and --store.config* parameters cannot be defined at the same time")
+		}
+
+		var fileSDConfig *file.SDConfig
 		if len(*fileSDFiles) > 0 {
-			conf := &file.SDConfig{
+			fileSDConfig := &file.SDConfig{
 				Files:           *fileSDFiles,
 				RefreshInterval: *fileSDInterval,
 			}
-			fileSD = file.NewDiscovery(conf, logger)
 		}
 
 		promql.SetDefaultEvaluationInterval(time.Duration(*defaultEvaluationInterval))
@@ -155,7 +169,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application) {
 			*stores,
 			*enableAutodownsampling,
 			*enablePartialResponse,
-			fileSD,
+			fileSDConfig,
+			storeConfigYAML,
 			time.Duration(*dnsSDInterval),
 			*dnsSDResolver,
 			time.Duration(*unhealthyStoreTimeout),
@@ -195,7 +210,8 @@ func runQuery(
 	storeAddrs []string,
 	enableAutodownsampling bool,
 	enablePartialResponse bool,
-	fileSD *file.Discovery,
+	fileSDConfig file.SDConfig,
+	storeConfigYAML []byte,
 	dnsSDInterval time.Duration,
 	dnsSDResolver string,
 	unhealthyStoreTimeout time.Duration,
@@ -209,20 +225,86 @@ func runQuery(
 	})
 	reg.MustRegister(duplicatedStores)
 
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, secure, cert, key, caCert, serverName)
-	if err != nil {
-		return errors.Wrap(err, "building gRPC client")
+
+	var storeCfg []store.Config
+	if len(storeConfigYAML) > 0 {
+		var err error
+		storeCfg, err = store.LoadConfigs(storeConfigYAML)
+		if err != nil {
+			return err
+		}
+	} else {
+		for _, addr := range storeAddrs {
+			if addr == "" {
+				return errors.New("static store address cannot be empty")
+			}
+		}
+
+		var tlsConfig store.TlsConfig
+		if secure {
+			tlsConfig = store.TlsConfig {
+				Cert: cert,
+				Key: key,
+				CaCert: caCert,
+				ServerName: serverName,
+			}
+		}
+		storeCfg = append(storeCfg,
+			store.Config{
+			    TlsConfig: &tlsConfig,
+				EndpointsConfig: store.EndpointsConfig {
+					StaticAddresses: storeAddrs,
+					FileSDConfigs: fileSDConfig,
+				},
+			},
+		)
+
 	}
 
-	fileSDCache := cache.New()
-	dnsProvider := dns.NewProvider(
-		logger,
-		extprom.WrapRegistererWithPrefix("thanos_querier_store_apis_", reg),
-		dns.ResolverType(dnsSDResolver),
+	var storeSets []*query.StoreSet
+	var (
+		allClients = func() []store.Client {
+			var ret []store.Client
+			for _, ss := range storeSets {
+				ret = append(ret, ss.Get()...)
+			}
+			return ret
+		}
+		proxy            = store.NewProxyStore(logger, reg, allClients, component.Query, selectorLset, storeResponseTimeout)
+		queryableCreator = query.NewQueryableCreator(logger, proxy)
+		engine           = promql.NewEngine(
+			promql.EngineOpts{
+				Logger:        logger,
+				Reg:           reg,
+				MaxConcurrent: maxConcurrentQueries,
+				// TODO(bwplotka): Expose this as a flag: https://github.com/thanos-io/thanos/issues/703.
+				MaxSamples: math.MaxInt32,
+				Timeout:    queryTimeout,
+			},
+		)
 	)
 
-	var (
-		stores = query.NewStoreSet(
+	for _, config := range storeCfg {
+		var fileSD *file.Discovery
+		if config.EndpointsConfig.FileSDConfigs != nil {
+			fileSD = file.NewDiscovery(fileSDConfig, logger)
+		}
+
+		dialOpts, err := extgrpc.StoreClientGRPCOptsFromTlsConfig(logger, reg, tracer, config.TlsConfig)
+		if err != nil {
+			return errors.Wrap(err, "building gRPC client")
+		}
+
+		fileSDCache := cache.New()
+		dnsProvider := dns.NewProvider(
+			logger,
+			// todo: sml: looks a bit iffy
+			extprom.WrapRegistererWithPrefix("thanos_querier_store_apis_", reg),
+			dns.ResolverType(dnsSDResolver),
+		)
+
+
+		stores := query.NewStoreSet(
 			logger,
 			reg,
 			func() (specs []query.StoreSpec) {
@@ -238,78 +320,68 @@ func runQuery(
 			dialOpts,
 			unhealthyStoreTimeout,
 		)
-		proxy            = store.NewProxyStore(logger, reg, stores.Get, component.Query, selectorLset, storeResponseTimeout)
-		queryableCreator = query.NewQueryableCreator(logger, proxy)
-		engine           = promql.NewEngine(
-			promql.EngineOpts{
-				Logger:        logger,
-				Reg:           reg,
-				MaxConcurrent: maxConcurrentQueries,
-				// TODO(bwplotka): Expose this as a flag: https://github.com/thanos-io/thanos/issues/703.
-				MaxSamples: math.MaxInt32,
-				Timeout:    queryTimeout,
-			},
-		)
-	)
-	// Periodically update the store set with the addresses we see in our cluster.
-	{
-		ctx, cancel := context.WithCancel(context.Background())
-		g.Add(func() error {
-			return runutil.Repeat(5*time.Second, ctx.Done(), func() error {
-				stores.Update(ctx)
-				return nil
-			})
-		}, func(error) {
-			cancel()
-			stores.Close()
-		})
-	}
-	// Run File Service Discovery and update the store set when the files are modified.
-	if fileSD != nil {
-		var fileSDUpdates chan []*targetgroup.Group
-		ctxRun, cancelRun := context.WithCancel(context.Background())
+		storeSets = append(storeSets, stores)
 
-		fileSDUpdates = make(chan []*targetgroup.Group)
-
-		g.Add(func() error {
-			fileSD.Run(ctxRun, fileSDUpdates)
-			return nil
-		}, func(error) {
-			cancelRun()
-		})
-
-		ctxUpdate, cancelUpdate := context.WithCancel(context.Background())
-		g.Add(func() error {
-			for {
-				select {
-				case update := <-fileSDUpdates:
-					// Discoverers sometimes send nil updates so need to check for it to avoid panics.
-					if update == nil {
-						continue
-					}
-					fileSDCache.Update(update)
-					stores.Update(ctxUpdate)
-					dnsProvider.Resolve(ctxUpdate, append(fileSDCache.Addresses(), storeAddrs...))
-				case <-ctxUpdate.Done():
+		// Periodically update the store set with the addresses we see in our cluster.
+		{
+			ctx, cancel := context.WithCancel(context.Background())
+			g.Add(func() error {
+				return runutil.Repeat(5*time.Second, ctx.Done(), func() error {
+					stores.Update(ctx)
 					return nil
-				}
-			}
-		}, func(error) {
-			cancelUpdate()
-			close(fileSDUpdates)
-		})
-	}
-	// Periodically update the addresses from static flags and file SD by resolving them using DNS SD if necessary.
-	{
-		ctx, cancel := context.WithCancel(context.Background())
-		g.Add(func() error {
-			return runutil.Repeat(dnsSDInterval, ctx.Done(), func() error {
-				dnsProvider.Resolve(ctx, append(fileSDCache.Addresses(), storeAddrs...))
-				return nil
+				})
+			}, func(error) {
+				cancel()
+				stores.Close()
 			})
-		}, func(error) {
-			cancel()
-		})
+		}
+		// Run File Service Discovery and update the store set when the files are modified.
+		if fileSD != nil {
+			var fileSDUpdates chan []*targetgroup.Group
+			ctxRun, cancelRun := context.WithCancel(context.Background())
+
+			fileSDUpdates = make(chan []*targetgroup.Group)
+
+			g.Add(func() error {
+				fileSD.Run(ctxRun, fileSDUpdates)
+				return nil
+			}, func(error) {
+				cancelRun()
+			})
+
+			ctxUpdate, cancelUpdate := context.WithCancel(context.Background())
+			g.Add(func() error {
+				for {
+					select {
+					case update := <-fileSDUpdates:
+						// Discoverers sometimes send nil updates so need to check for it to avoid panics.
+						if update == nil {
+							continue
+						}
+						fileSDCache.Update(update)
+						stores.Update(ctxUpdate)
+						dnsProvider.Resolve(ctxUpdate, append(fileSDCache.Addresses(), config.EndpointsConfig.StaticAddresses...))
+					case <-ctxUpdate.Done():
+						return nil
+					}
+				}
+			}, func(error) {
+				cancelUpdate()
+				close(fileSDUpdates)
+			})
+		}
+		// Periodically update the addresses from static flags and file SD by resolving them using DNS SD if necessary.
+		{
+			ctx, cancel := context.WithCancel(context.Background())
+			g.Add(func() error {
+				return runutil.Repeat(dnsSDInterval, ctx.Done(), func() error {
+					dnsProvider.Resolve(ctx, append(fileSDCache.Addresses(), config.EndpointsConfig.StaticAddresses...))
+					return nil
+				})
+			}, func(error) {
+				cancel()
+			})
+		}
 	}
 
 	grpcProbe := prober.NewGRPC()

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -194,7 +194,7 @@ func runReceive(
 	if err != nil {
 		return err
 	}
-	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
+	dialOpts, err := extgrpc.StoreClientGRPCOpts(logger, nil, reg, tracer, rwServerCert != "", rwClientCert, rwClientKey, rwClientServerCA, rwClientServerName)
 	if err != nil {
 		return err
 	}

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -364,7 +364,6 @@ The configuration format is the following:
 
 [embedmd]:# (../flags/config_query_store.txt yaml)
 ```yaml
-stores:
 - tls_config:
     ca_file: ""
     cert_file: ""

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -354,3 +354,26 @@ Flags:
                                  enabled. 0 disables timeout.
 
 ```
+## Configuration
+
+### Store API
+
+The `--store.config` and `--store.config-file` flags allow specifying multiple store endpoints.
+
+The configuration format is the following:
+
+[embedmd]:# (../flags/config_query_store.txt yaml)
+```yaml
+stores:
+- tls_config:
+    ca_file: ""
+    cert_file: ""
+    key_file: ""
+    server_name: ""
+  static_configs: []
+  file_sd_configs:
+  - files: []
+    refresh_interval: 0s
+```
+
+If `tls_config` is omitted or set to `null` then TLS will not be used.

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,6 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/yaml.v2 v2.2.7
-	sigs.k8s.io/yaml v1.1.0
 )
 
 // We want to replace the client-go version with a specific commit hash,

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	cloud.google.com/go v0.49.0
 	cloud.google.com/go/storage v1.3.0
 	github.com/Azure/azure-storage-blob-go v0.8.0
+	github.com/Azure/go-autorest/autorest v0.10.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
 	github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible
@@ -47,7 +48,7 @@ require (
 	go.elastic.co/apm v1.5.0
 	go.elastic.co/apm/module/apmot v1.5.0
 	go.uber.org/automaxprocs v1.2.0
-	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708
+	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/text v0.3.2
@@ -58,6 +59,7 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/yaml.v2 v2.2.7
+	sigs.k8s.io/yaml v1.1.0
 )
 
 // We want to replace the client-go version with a specific commit hash,

--- a/go.sum
+++ b/go.sum
@@ -35,9 +35,13 @@ github.com/Azure/go-autorest v12.3.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSW
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.3-0.20191028180845-3492b2aff503 h1:uUhdsDMg2GbFLF5GfQPtLMWd5vdDZSfqvqQp3waafxQ=
 github.com/Azure/go-autorest/autorest v0.9.3-0.20191028180845-3492b2aff503/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
+github.com/Azure/go-autorest/autorest v0.10.0 h1:mvdtztBqcL8se7MdrUweNieTNi4kfNG6GOJuurQJpuY=
+github.com/Azure/go-autorest/autorest v0.10.0/go.mod h1:/FALq9T/kS7b5J5qsQ+RSTUdAmGFqi0vUdVNNx8q630=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/adal v0.8.1-0.20191028180845-3492b2aff503 h1:Hxqlh1uAA8aGpa1dFhDNhll7U/rkWtG8ZItFvRMr7l0=
 github.com/Azure/go-autorest/autorest/adal v0.8.1-0.20191028180845-3492b2aff503/go.mod h1:Z6vX6WXXuyieHAXwMj0S6HY6e6wcHn37qQMBQlvY3lc=
+github.com/Azure/go-autorest/autorest/adal v0.8.2 h1:O1X4oexUxnZCaEUGsvMnr8ZGj8HI37tNezwY4npRqA0=
+github.com/Azure/go-autorest/autorest/adal v0.8.2/go.mod h1:ZjhuQClTqx435SRJ2iMlOxPYt3d2C/T/7TiQCVZSn3Q=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/date v0.2.0 h1:yW+Zlqf26583pE43KhfnhFcdmSWlm5Ew6bxipnr/tbM=
 github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+vPmf1Ij9AEBM5FuBIXLmIy0g=
@@ -750,6 +754,8 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 h1:pXVtWnwHkrWD9ru3sDxY/qFK/bfc0egRovX91EjWjf4=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -34,7 +34,7 @@ func StoreClientGRPCOpts(logger log.Logger, clientInstance *string, reg *prometh
 		[]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 	)
 	if clientInstance != nil {
-		constLabels := map[string]string{"client_instance": *clientInstance}
+		constLabels := map[string]string{"config_name": *clientInstance}
 		grpcMets = grpc_prometheus.NewClientMetrics(grpc_prometheus.WithConstLabels(constLabels))
 		grpcMets.EnableClientHandlingTimeHistogram(
 			grpc_prometheus.WithHistogramConstLabels(constLabels),

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -4,6 +4,7 @@
 package extgrpc
 
 import (
+	"github.com/thanos-io/thanos/pkg/store"
 	"math"
 
 	"github.com/go-kit/kit/log"
@@ -17,6 +18,14 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
+
+func StoreClientGRPCOptsFromTlsConfig(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, tlsConfig *store.TlsConfig) ([]grpc.DialOption, error) {
+	if tlsConfig != nil {
+		return StoreClientGRPCOpts(logger, reg, tracer, true, tlsConfig.Cert, tlsConfig.Key, tlsConfig.CaCert, tlsConfig.ServerName)
+	} else {
+		return StoreClientGRPCOpts(logger, reg, tracer, false, tlsConfig.Cert, tlsConfig.Key, tlsConfig.CaCert, tlsConfig.ServerName)
+	}
+}
 
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
 func StoreClientGRPCOpts(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -30,14 +30,20 @@ func StoreClientGRPCOptsFromTlsConfig(logger log.Logger, clientInstance string, 
 // StoreClientGRPCOpts creates gRPC dial options for connecting to a store client.
 func StoreClientGRPCOpts(logger log.Logger, clientInstance *string, reg *prometheus.Registry, tracer opentracing.Tracer, secure bool, cert, key, caCert, serverName string) ([]grpc.DialOption, error) {
 	var grpcMets *grpc_prometheus.ClientMetrics
+	histogramBuckets := grpc_prometheus.WithHistogramBuckets(
+		[]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
+	)
 	if clientInstance != nil {
-		grpcMets = grpc_prometheus.NewClientMetrics(grpc_prometheus.WithConstLabels(map[string]string{"clientInstance": *clientInstance}))
+		constLabels := map[string]string{"client_instance": *clientInstance}
+		grpcMets = grpc_prometheus.NewClientMetrics(grpc_prometheus.WithConstLabels(constLabels))
+		grpcMets.EnableClientHandlingTimeHistogram(
+			grpc_prometheus.WithHistogramConstLabels(constLabels),
+			histogramBuckets,
+		)
 	} else {
 		grpcMets = grpc_prometheus.NewClientMetrics()
+		grpcMets.EnableClientHandlingTimeHistogram(histogramBuckets)
 	}
-	grpcMets.EnableClientHandlingTimeHistogram(
-		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
-	)
 	dialOpts := []grpc.DialOption{
 		// We want to make sure that we can receive huge gRPC messages from storeAPI.
 		// On TCP level we can be fine, but the gRPC overhead for huge messages could be significant.

--- a/pkg/extgrpc/client.go
+++ b/pkg/extgrpc/client.go
@@ -23,7 +23,7 @@ func StoreClientGRPCOptsFromTlsConfig(logger log.Logger, reg *prometheus.Registr
 	if tlsConfig != nil {
 		return StoreClientGRPCOpts(logger, reg, tracer, true, tlsConfig.Cert, tlsConfig.Key, tlsConfig.CaCert, tlsConfig.ServerName)
 	} else {
-		return StoreClientGRPCOpts(logger, reg, tracer, false, tlsConfig.Cert, tlsConfig.Key, tlsConfig.CaCert, tlsConfig.ServerName)
+		return StoreClientGRPCOpts(logger, reg, tracer, false, "", "", "", "")
 	}
 }
 

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -149,7 +149,7 @@ type FileSDConfig struct {
 	RefreshInterval model.Duration `yaml:"refresh_interval"`
 }
 
-func (c FileSDConfig) convert() (file.SDConfig, error) {
+func (c FileSDConfig) Convert() (file.SDConfig, error) {
 	var fileSDConfig file.SDConfig
 	b, err := yaml.Marshal(c)
 	if err != nil {
@@ -190,7 +190,7 @@ func NewClient(logger log.Logger, cfg EndpointsConfig, client *http.Client, prov
 
 	var discoverers []*file.Discovery
 	for _, sdCfg := range cfg.FileSDConfigs {
-		fileSDCfg, err := sdCfg.convert()
+		fileSDCfg, err := sdCfg.Convert()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -94,14 +94,14 @@ func newStoreSetNodeCollector(configInstance string) *storeSetNodeCollector {
 		connectionsDesc: prometheus.NewDesc(
 			"thanos_store_nodes_grpc_connections",
 			"Number of gRPC connection to Store APIs. Opened connection means healthy store APIs available for Querier.",
-			[]string{"external_labels", "store_type"}, map[string]string{"configInstance":configInstance},
+			[]string{"external_labels", "store_type"}, map[string]string{"config_instance":configInstance},
 		),
 		// TODO(bwplotka): Obsolete; Replaced by thanos_store_nodes_grpc_connections.
 		// Remove in next minor release.
 		nodeInfoDesc: prometheus.NewDesc(
 			"thanos_store_node_info",
 			"Deprecated, use thanos_store_nodes_grpc_connections instead.",
-			[]string{"external_labels"}, map[string]string{"configInstance":configInstance},
+			[]string{"external_labels"}, map[string]string{"config_instance":configInstance},
 		),
 	}
 }

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -84,24 +84,24 @@ type storeSetNodeCollector struct {
 	storeNodes      map[component.StoreAPI]map[string]int
 	storePerExtLset map[string]int
 
-	connectionsDesc *prometheus.Desc
-	nodeInfoDesc    *prometheus.Desc
+	connectionsDesc    *prometheus.Desc
+	nodeInfoDesc       *prometheus.Desc
 }
 
-func newStoreSetNodeCollector() *storeSetNodeCollector {
+func newStoreSetNodeCollector(configInstance string) *storeSetNodeCollector {
 	return &storeSetNodeCollector{
 		storeNodes: map[component.StoreAPI]map[string]int{},
 		connectionsDesc: prometheus.NewDesc(
 			"thanos_store_nodes_grpc_connections",
 			"Number of gRPC connection to Store APIs. Opened connection means healthy store APIs available for Querier.",
-			[]string{"external_labels", "store_type"}, nil,
+			[]string{"external_labels", "store_type"}, map[string]string{"configInstance":configInstance},
 		),
 		// TODO(bwplotka): Obsolete; Replaced by thanos_store_nodes_grpc_connections.
 		// Remove in next minor release.
 		nodeInfoDesc: prometheus.NewDesc(
 			"thanos_store_node_info",
 			"Deprecated, use thanos_store_nodes_grpc_connections instead.",
-			[]string{"external_labels"}, nil,
+			[]string{"external_labels"}, map[string]string{"configInstance":configInstance},
 		),
 	}
 }
@@ -174,12 +174,13 @@ type StoreSet struct {
 // NewStoreSet returns a new set of stores from cluster peers and statically configured ones.
 func NewStoreSet(
 	logger log.Logger,
+	configInstance string,
 	reg *prometheus.Registry,
 	storeSpecs func() []StoreSpec,
 	dialOpts []grpc.DialOption,
 	unhealthyStoreTimeout time.Duration,
 ) *StoreSet {
-	storesMetric := newStoreSetNodeCollector()
+	storesMetric := newStoreSetNodeCollector(configInstance)
 	if reg != nil {
 		reg.MustRegister(storesMetric)
 	}

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -94,14 +94,14 @@ func newStoreSetNodeCollector(configInstance string) *storeSetNodeCollector {
 		connectionsDesc: prometheus.NewDesc(
 			"thanos_store_nodes_grpc_connections",
 			"Number of gRPC connection to Store APIs. Opened connection means healthy store APIs available for Querier.",
-			[]string{"external_labels", "store_type"}, map[string]string{"config_instance":configInstance},
+			[]string{"external_labels", "store_type"}, map[string]string{"config_name":configInstance},
 		),
 		// TODO(bwplotka): Obsolete; Replaced by thanos_store_nodes_grpc_connections.
 		// Remove in next minor release.
 		nodeInfoDesc: prometheus.NewDesc(
 			"thanos_store_node_info",
 			"Deprecated, use thanos_store_nodes_grpc_connections instead.",
-			[]string{"external_labels"}, map[string]string{"config_instance":configInstance},
+			[]string{"external_labels"}, map[string]string{"config_name":configInstance},
 		),
 	}
 }

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -210,6 +210,7 @@ type storeRef struct {
 	mtx  sync.RWMutex
 	cc   *grpc.ClientConn
 	addr string
+	dialOpts []grpc.DialOption
 
 	// Meta (can change during runtime).
 	labelSets []storepb.LabelSet

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -1,7 +1,7 @@
 package store
 
 import (
-	http_util "github.com/thanos-io/thanos/pkg/http"
+	"github.com/prometheus/prometheus/discovery/file"
 	"sigs.k8s.io/yaml"
 )
 
@@ -21,14 +21,16 @@ type EndpointsConfig struct {
 	// List of addresses with DNS prefixes.
 	StaticAddresses []string `yaml:"static_configs"`
 	// List of file  configurations (our FileSD supports different DNS lookups).
-	FileSDConfigs []http_util.FileSDConfig `yaml:"file_sd_configs"`
+	FileSDConfigs []file.SDConfig `yaml:"file_sd_configs"`
 }
+
+
 
 func DefaultConfig() Config {
 	return Config{
 		EndpointsConfig: EndpointsConfig{
 			StaticAddresses: []string{},
-			FileSDConfigs:   []http_util.FileSDConfig{},
+			FileSDConfigs:   []file.SDConfig{},
 		},
 	}
 }

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	http_util "github.com/thanos-io/thanos/pkg/http"
+	"sigs.k8s.io/yaml"
+)
+
+type Config struct {
+	TlsConfig *TlsConfig    `yaml:"tls_config"`
+	EndpointsConfig  EndpointsConfig `yaml:",inline"`
+}
+
+type TlsConfig struct {
+	Cert string
+	Key string
+	CaCert string
+	ServerName string
+}
+
+type EndpointsConfig struct {
+	// List of addresses with DNS prefixes.
+	StaticAddresses []string `yaml:"static_configs"`
+	// List of file  configurations (our FileSD supports different DNS lookups).
+	FileSDConfigs []http_util.FileSDConfig `yaml:"file_sd_configs"`
+}
+
+func DefaultConfig() Config {
+	return Config{
+		EndpointsConfig: EndpointsConfig{
+			StaticAddresses: []string{},
+			FileSDConfigs:   []http_util.FileSDConfig{},
+		},
+	}
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultConfig()
+	type plain Config
+	return unmarshal((*plain)(c))
+}
+
+// LoadConfigs loads a list of Config from YAML data.
+func LoadConfigs(confYAML []byte) ([]Config, error) {
+	var queryCfg []Config
+	if err := yaml.UnmarshalStrict(confYAML, &queryCfg); err != nil {
+		return nil, err
+	}
+	return queryCfg, nil
+}

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -6,26 +6,26 @@ import (
 )
 
 type Config struct {
-	TlsConfig *TlsConfig    `yaml:"tls_config"`
-	EndpointsConfig  EndpointsConfig `yaml:",inline"`
+	TlsConfig *TlsConfig    `yaml:"tls_config" json:"tls_config"`
+	EndpointsConfig  EndpointsConfig `yaml:",inline" json:",inline"`
 }
 
 type TlsConfig struct {
 	// TLS Certificates to use to identify this client to the server
-	Cert string `yaml:"cert_file"`
+	Cert string `yaml:"cert_file" json:"cert_file"`
 	// TLS Key for the client's certificate
-	Key string `yaml:"key_file"`
+	Key string `yaml:"key_file" json:"key_file"`
 	// TLS CA Certificates to use to verify gRPC servers
-	CaCert string `yaml:"ca_file"`
+	CaCert string `yaml:"ca_file" json:"ca_file"`
 	// Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
-	ServerName string `yaml:"server_name"`
+	ServerName string `yaml:"server_name" json:"server_name"`
 }
 
 type EndpointsConfig struct {
 	// List of addresses with DNS prefixes.
-	StaticAddresses []string `yaml:"static_configs"`
+	StaticAddresses []string `yaml:"static_configs" json:"static_configs"`
 	// List of file  configurations (our FileSD supports different DNS lookups).
-	FileSDConfigs []file.SDConfig `yaml:"file_sd_configs"`
+	FileSDConfigs []file.SDConfig `yaml:"file_sd_configs" json:"file_sd_configs"`
 }
 
 
@@ -49,7 +49,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // LoadConfigs loads a list of Config from YAML data.
 func LoadConfig(confYAML []byte) ([]Config, error) {
 	var queryCfg []Config
-	if err := yaml.UnmarshalStrict(confYAML, queryCfg); err != nil {
+	if err := yaml.UnmarshalStrict(confYAML, &queryCfg); err != nil {
 		return nil, err
 	}
 	return queryCfg, nil

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -6,19 +6,23 @@ import (
 )
 
 type Config struct {
+	Stores []StoresConfig    `yaml:"stores"`
+}
+
+type StoresConfig struct {
 	TlsConfig *TlsConfig    `yaml:"tls_config"`
 	EndpointsConfig  EndpointsConfig `yaml:",inline"`
 }
 
 type TlsConfig struct {
 	// TLS Certificates to use to identify this client to the server
-	Cert string `yaml:"cert"`
+	Cert string `yaml:"cert_file"`
 	// TLS Key for the client's certificate
-	Key string `yaml:"key"`
+	Key string `yaml:"key_file"`
 	// TLS CA Certificates to use to verify gRPC servers
-	CaCert string `yaml:"ca"`
+	CaCert string `yaml:"ca_file"`
 	// Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
-	ServerName string `yaml:"server-name"`
+	ServerName string `yaml:"server_name"`
 }
 
 type EndpointsConfig struct {
@@ -32,9 +36,13 @@ type EndpointsConfig struct {
 
 func DefaultConfig() Config {
 	return Config{
-		EndpointsConfig: EndpointsConfig{
-			StaticAddresses: []string{},
-			FileSDConfigs:   []file.SDConfig{},
+		Stores:[]StoresConfig{
+			StoresConfig{
+				EndpointsConfig: EndpointsConfig{
+					StaticAddresses: []string{},
+					FileSDConfigs:   []file.SDConfig{},
+				},
+			},
 		},
 	}
 }
@@ -47,9 +55,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // LoadConfigs loads a list of Config from YAML data.
-func LoadConfigs(confYAML []byte) ([]Config, error) {
-	var queryCfg []Config
-	if err := yaml.UnmarshalStrict(confYAML, &queryCfg); err != nil {
+func LoadConfig(confYAML []byte) (*Config, error) {
+	var queryCfg *Config
+	if err := yaml.UnmarshalStrict(confYAML, queryCfg); err != nil {
 		return nil, err
 	}
 	return queryCfg, nil

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -1,31 +1,32 @@
 package store
 
 import (
+	"gopkg.in/yaml.v2"
+
 	"github.com/prometheus/prometheus/discovery/file"
-	"sigs.k8s.io/yaml"
 )
 
 type Config struct {
-	TlsConfig *TlsConfig    `yaml:"tls_config" json:"tls_config"`
-	EndpointsConfig  EndpointsConfig `yaml:",inline" json:",inline"`
+	TlsConfig *TlsConfig    `yaml:"tls_config"`
+	EndpointsConfig  EndpointsConfig `yaml:",inline"`
 }
 
 type TlsConfig struct {
 	// TLS Certificates to use to identify this client to the server
-	Cert string `yaml:"cert_file" json:"cert_file"`
+	Cert string `yaml:"cert_file"`
 	// TLS Key for the client's certificate
-	Key string `yaml:"key_file" json:"key_file"`
+	Key string `yaml:"key_file"`
 	// TLS CA Certificates to use to verify gRPC servers
-	CaCert string `yaml:"ca_file" json:"ca_file"`
+	CaCert string `yaml:"ca_file"`
 	// Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
-	ServerName string `yaml:"server_name" json:"server_name"`
+	ServerName string `yaml:"server_name"`
 }
 
 type EndpointsConfig struct {
 	// List of addresses with DNS prefixes.
-	StaticAddresses []string `yaml:"static_configs" json:"static_configs"`
+	StaticAddresses []string `yaml:"static_configs"`
 	// List of file  configurations (our FileSD supports different DNS lookups).
-	FileSDConfigs []file.SDConfig `yaml:"file_sd_configs" json:"file_sd_configs"`
+	FileSDConfigs []file.SDConfig `yaml:"file_sd_configs"`
 }
 
 

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -11,10 +11,14 @@ type Config struct {
 }
 
 type TlsConfig struct {
-	Cert string
-	Key string
-	CaCert string
-	ServerName string
+	// TLS Certificates to use to identify this client to the server
+	Cert string `yaml:"cert"`
+	// TLS Key for the client's certificate
+	Key string `yaml:"key"`
+	// TLS CA Certificates to use to verify gRPC servers
+	CaCert string `yaml:"ca"`
+	// Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
+	ServerName string `yaml:"server-name"`
 }
 
 type EndpointsConfig struct {

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -6,10 +6,6 @@ import (
 )
 
 type Config struct {
-	Stores []StoresConfig    `yaml:"stores"`
-}
-
-type StoresConfig struct {
 	TlsConfig *TlsConfig    `yaml:"tls_config"`
 	EndpointsConfig  EndpointsConfig `yaml:",inline"`
 }
@@ -36,13 +32,9 @@ type EndpointsConfig struct {
 
 func DefaultConfig() Config {
 	return Config{
-		Stores:[]StoresConfig{
-			StoresConfig{
-				EndpointsConfig: EndpointsConfig{
-					StaticAddresses: []string{},
-					FileSDConfigs:   []file.SDConfig{},
-				},
-			},
+		EndpointsConfig: EndpointsConfig{
+			StaticAddresses: []string{},
+			FileSDConfigs:   []file.SDConfig{},
 		},
 	}
 }
@@ -55,8 +47,8 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // LoadConfigs loads a list of Config from YAML data.
-func LoadConfig(confYAML []byte) (*Config, error) {
-	var queryCfg *Config
+func LoadConfig(confYAML []byte) ([]Config, error) {
+	var queryCfg []Config
 	if err := yaml.UnmarshalStrict(confYAML, queryCfg); err != nil {
 		return nil, err
 	}

--- a/pkg/store/config.go
+++ b/pkg/store/config.go
@@ -1,30 +1,32 @@
 package store
 
 import (
+	"errors"
 	"gopkg.in/yaml.v2"
 
 	"github.com/prometheus/prometheus/discovery/file"
 )
 
 type Config struct {
-	TlsConfig *TlsConfig    `yaml:"tls_config"`
+	Name string                      `yaml:"name"`
+	TlsConfig *TlsConfig             `yaml:"tls_config"`
 	EndpointsConfig  EndpointsConfig `yaml:",inline"`
 }
 
 type TlsConfig struct {
 	// TLS Certificates to use to identify this client to the server
-	Cert string `yaml:"cert_file"`
+	Cert string       `yaml:"cert_file"`
 	// TLS Key for the client's certificate
-	Key string `yaml:"key_file"`
+	Key string        `yaml:"key_file"`
 	// TLS CA Certificates to use to verify gRPC servers
-	CaCert string `yaml:"ca_file"`
+	CaCert string     `yaml:"ca_file"`
 	// Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1
 	ServerName string `yaml:"server_name"`
 }
 
 type EndpointsConfig struct {
 	// List of addresses with DNS prefixes.
-	StaticAddresses []string `yaml:"static_configs"`
+	StaticAddresses []string      `yaml:"static_configs"`
 	// List of file  configurations (our FileSD supports different DNS lookups).
 	FileSDConfigs []file.SDConfig `yaml:"file_sd_configs"`
 }
@@ -33,6 +35,7 @@ type EndpointsConfig struct {
 
 func DefaultConfig() Config {
 	return Config{
+		Name: "default",
 		EndpointsConfig: EndpointsConfig{
 			StaticAddresses: []string{},
 			FileSDConfigs:   []file.SDConfig{},
@@ -52,6 +55,15 @@ func LoadConfig(confYAML []byte) ([]Config, error) {
 	var queryCfg []Config
 	if err := yaml.UnmarshalStrict(confYAML, &queryCfg); err != nil {
 		return nil, err
+	}
+	seenNames := map[string]string{}
+	for _, cfg := range queryCfg {
+		if _, exists := seenNames[cfg.Name]; exists {
+			return nil, errors.New("config must have a non-empty, unique name")
+		} else {
+			seenNames[cfg.Name] = cfg.Name
+		}
+
 	}
 	return queryCfg, nil
 }

--- a/pkg/ui/query.go
+++ b/pkg/ui/query.go
@@ -24,7 +24,7 @@ import (
 
 type Query struct {
 	*BaseUI
-	storeSet *query.StoreSet
+	getStoreStatus func() []query.StoreStatus
 
 	flagsMap map[string]string
 
@@ -43,14 +43,14 @@ type thanosVersion struct {
 	GoVersion string `json:"goVersion"`
 }
 
-func NewQueryUI(logger log.Logger, reg prometheus.Registerer, storeSet *query.StoreSet, flagsMap map[string]string) *Query {
+func NewQueryUI(logger log.Logger, reg prometheus.Registerer, getStoreStatus func() []query.StoreStatus, flagsMap map[string]string) *Query {
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = "<error retrieving current working directory>"
 	}
 	return &Query{
 		BaseUI:   NewBaseUI(logger, "query_menu.html", queryTmplFuncs()),
-		storeSet: storeSet,
+		getStoreStatus: getStoreStatus,
 		flagsMap: flagsMap,
 		cwd:      cwd,
 		birth:    time.Now(),
@@ -125,7 +125,7 @@ func (q *Query) status(w http.ResponseWriter, r *http.Request) {
 func (q *Query) stores(w http.ResponseWriter, r *http.Request) {
 	prefix := GetWebPrefix(q.logger, q.flagsMap, r)
 	statuses := make(map[component.StoreAPI][]query.StoreStatus)
-	for _, status := range q.storeSet.GetStoreStatus() {
+	for _, status := range q.getStoreStatus() {
 		statuses[status.StoreType] = append(statuses[status.StoreType], status)
 	}
 

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -6,7 +6,14 @@ package e2e_test
 import (
 	"context"
 	"fmt"
+	"github.com/prometheus/prometheus/discovery/file"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/thanos-io/thanos/pkg/store"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
 	"net/url"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -62,6 +69,30 @@ func sortResults(res model.Vector) {
 	})
 }
 
+func createSDFile(sharedDir string, querierName string, fileSDStoreAddresses []string) (string, error) {
+	queryFileSDDir := filepath.Join(sharedDir, "data", "querier", querierName)
+	container := filepath.Join(e2e.ContainerSharedDir, "data", "querier", querierName)
+	if err := os.MkdirAll(queryFileSDDir, 0777); err != nil {
+		return "", errors.Wrap(err, "create query dir failed")
+	}
+
+	fileSD := []*targetgroup.Group{{}}
+	for _, a := range fileSDStoreAddresses {
+		fileSD[0].Targets = append(fileSD[0].Targets, model.LabelSet{model.AddressLabel: model.LabelValue(a)})
+	}
+
+	b, err := yaml.Marshal(fileSD)
+	if err != nil {
+		return "", err
+	}
+
+	if err := ioutil.WriteFile(queryFileSDDir+"/filesd.yaml", b, 0666); err != nil {
+		return "", errors.Wrap(err, "creating query SD config failed")
+	}
+
+	return filepath.Join(container, "filesd.yaml"), nil
+}
+
 func TestQuery(t *testing.T) {
 	t.Parallel()
 
@@ -83,12 +114,30 @@ func TestQuery(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(prom1, sidecar1, prom2, sidecar2, prom3, sidecar3, prom4, sidecar4))
 
-	// Querier. Both fileSD and directly by flags.
-	q, err := e2ethanos.NewQuerier(
-		s.SharedDir(), "1",
-		[]string{sidecar1.GRPCNetworkEndpoint(), sidecar2.GRPCNetworkEndpoint(), receiver.GRPCNetworkEndpoint()},
-		[]string{sidecar3.GRPCNetworkEndpoint(), sidecar4.GRPCNetworkEndpoint()},
-	)
+	sdFilePath, err := createSDFile(s.SharedDir(), "1", []string{sidecar3.GRPCNetworkEndpoint(), sidecar4.GRPCNetworkEndpoint()})
+	testutil.Ok(t, err)
+
+	// Both fileSD and directly by seperate configs
+	queryCfg := []store.Config{
+		{
+			EndpointsConfig: store.EndpointsConfig{
+				StaticAddresses: []string{sidecar1.GRPCNetworkEndpoint(), sidecar2.GRPCNetworkEndpoint(), receiver.GRPCNetworkEndpoint()},
+			},
+		},
+		{
+			EndpointsConfig: store.EndpointsConfig{
+				FileSDConfigs: []file.SDConfig{
+					{
+						Files: []string{sdFilePath},
+						RefreshInterval: 60,
+					},
+				},
+			},
+		},
+	}
+
+	// Querier.
+	q, err := e2ethanos.NewQuerier("1", queryCfg)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(q))
 

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -137,7 +137,7 @@ func TestQuery(t *testing.T) {
 	}
 
 	// Querier.
-	q, err := e2ethanos.NewQuerier("1", queryCfg)
+	q, err := e2ethanos.NewQuerier("99", queryCfg)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(q))
 

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -90,7 +90,7 @@ func createSDFile(sharedDir string, querierName string, fileSDStoreAddresses []s
 		return "", errors.Wrap(err, "creating query SD config failed")
 	}
 
-	fmt.Printf("filesd.yaml: %s\n", string(b))
+	fmt.Println("filesd.yaml:", string(b))
 
 	return filepath.Join(container, "filesd.yaml"), nil
 }

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -122,11 +122,13 @@ func TestQuery(t *testing.T) {
 	// Both fileSD and directly by seperate configs
 	queryCfg := []store.Config{
 		{
+			Name: "static",
 			EndpointsConfig: store.EndpointsConfig{
 				StaticAddresses: []string{sidecar1.GRPCNetworkEndpoint(), sidecar2.GRPCNetworkEndpoint(), receiver.GRPCNetworkEndpoint()},
 			},
 		},
 		{
+			Name: "filesd",
 			EndpointsConfig: store.EndpointsConfig{
 				FileSDConfigs: []file.SDConfig{
 					{

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -90,6 +90,8 @@ func createSDFile(sharedDir string, querierName string, fileSDStoreAddresses []s
 		return "", errors.Wrap(err, "creating query SD config failed")
 	}
 
+	fmt.Printf("filesd.yaml: %s\n", string(b))
+
 	return filepath.Join(container, "filesd.yaml"), nil
 }
 

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -129,7 +129,7 @@ func TestQuery(t *testing.T) {
 				FileSDConfigs: []file.SDConfig{
 					{
 						Files: []string{sdFilePath},
-						RefreshInterval: 60,
+						RefreshInterval: model.Duration(time.Minute),
 					},
 				},
 			},

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -5,6 +5,7 @@ package e2e_test
 
 import (
 	"context"
+	"github.com/thanos-io/thanos/pkg/store"
 	"testing"
 	"time"
 
@@ -64,7 +65,14 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(prom1, prom2, prom3))
 
-		q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint(), r3.GRPCNetworkEndpoint()}, nil)
+		storeCfg := []store.Config{
+			{
+				EndpointsConfig: store.EndpointsConfig{
+					StaticAddresses: []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint(), r3.GRPCNetworkEndpoint()},
+				},
+			},
+		}
+		q, err := e2ethanos.NewQuerier("1", storeCfg)
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(q))
 
@@ -136,7 +144,14 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(prom1))
 
-		q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint(), r3.GRPCNetworkEndpoint()}, nil)
+		storeCfg := []store.Config{
+			{
+				EndpointsConfig: store.EndpointsConfig{
+					StaticAddresses: []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint(), r3.GRPCNetworkEndpoint()},
+				},
+			},
+		}
+		q, err := e2ethanos.NewQuerier("1", storeCfg)
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(q))
 
@@ -205,7 +220,14 @@ func TestReceive(t *testing.T) {
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(prom1))
 
-		q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint()}, nil)
+		storeCfg := []store.Config{
+			{
+				EndpointsConfig: store.EndpointsConfig{
+					StaticAddresses: []string{r1.GRPCNetworkEndpoint(), r2.GRPCNetworkEndpoint()},
+				},
+			},
+		}
+		q, err := e2ethanos.NewQuerier("1", storeCfg)
 		testutil.Ok(t, err)
 		testutil.Ok(t, s.StartAndWaitReady(q))
 

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"github.com/thanos-io/thanos/pkg/store"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -235,7 +236,7 @@ func TestRule_AlertmanagerHTTPClient(t *testing.T) {
 		{
 			EndpointsConfig: http_util.EndpointsConfig{
 				StaticAddresses: func() []string {
-					q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", nil, nil)
+					q, err := e2ethanos.NewQuerier("1", []store.Config{})
 					testutil.Ok(t, err)
 					return []string{q.NetworkHTTPEndpointFor(s.NetworkName())}
 				}(),
@@ -246,7 +247,14 @@ func TestRule_AlertmanagerHTTPClient(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(r))
 
-	q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r.GRPCNetworkEndpoint()}, nil)
+	storeCfg := []store.Config{
+		{
+			EndpointsConfig: store.EndpointsConfig{
+				StaticAddresses: []string{r.GRPCNetworkEndpoint()},
+			},
+		},
+	}
+	q, err := e2ethanos.NewQuerier("1", storeCfg)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(q))
 
@@ -322,7 +330,14 @@ func TestRule(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(r))
 
-	q, err := e2ethanos.NewQuerier(s.SharedDir(), "1", []string{r.GRPCNetworkEndpoint()}, nil)
+	storeCfg := []store.Config{
+		{
+			EndpointsConfig: store.EndpointsConfig{
+				StaticAddresses: []string{r.GRPCNetworkEndpoint()},
+			},
+		},
+	}
+	q, err := e2ethanos.NewQuerier("1", storeCfg)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(q))
 

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -5,6 +5,7 @@ package e2e_test
 
 import (
 	"context"
+	"github.com/thanos-io/thanos/pkg/store"
 	"os"
 	"path"
 	"path/filepath"
@@ -57,9 +58,14 @@ func TestStoreGateway(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(s1))
 
-	q, err := e2ethanos.NewQuerier(
-		s.SharedDir(), "1",
-		[]string{s1.GRPCNetworkEndpoint()}, nil)
+	storeCfg := []store.Config{
+		{
+			EndpointsConfig: store.EndpointsConfig{
+				StaticAddresses: []string{s1.GRPCNetworkEndpoint()},
+			},
+		},
+	}
+	q, err := e2ethanos.NewQuerier("1", storeCfg)
 	testutil.Ok(t, err)
 	testutil.Ok(t, s.StartAndWaitReady(q))
 


### PR DESCRIPTION
Closes https://github.com/thanos-io/thanos/issues/977

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This change adds support for reading stores from an external configuration file, with TLS and file SD configuration variable between sets of stores.

It is backwards compatible with existing flags for specifying stores, TLS and file SD.

## Verification

<!-- How you tested it? How do you know it works? -->
**TODO**
